### PR TITLE
Updated embedded_hal version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ version = "0.1.0"
 
 [dependencies]
 bit_field = "0.9.0"
-embedded-hal = "0.1.2"
+embedded-hal = "0.2.2"


### PR DESCRIPTION
This allows this crate to be used with HAL crates that implement the newest version of the embedded_hal.